### PR TITLE
Changes in paths and avoid move operation risks

### DIFF
--- a/GUI/view_main.py
+++ b/GUI/view_main.py
@@ -80,7 +80,9 @@ class MainWindow(wx.Frame):
 
 
         ''' Logo '''
-        self.img_logo = wx.Image("../Resources/logo.png", wx.BITMAP_TYPE_ANY)
+        cwd = os.getcwd()
+        path = os.path.join(cwd, "Resources", "logo.png")
+        self.img_logo = wx.Image(path, wx.BITMAP_TYPE_ANY)
         self.sb1 = wx.StaticBitmap(self.panel, -1, wx.BitmapFromImage(self.img_logo))
         ''' Text labels '''
 
@@ -168,7 +170,7 @@ class MainWindow(wx.Frame):
         self.SetMaxSize(self.GetSize())
         self.Center()
 
-        self.default_config_path = '../Sorter/config.json'
+        self.default_config_path = os.path.join(cwd, "Sorter", "config.json")
         if os.path.isfile(self.default_config_path):
             config_display_data = self.config.load_config(self.default_config_path)
             self.textbox_download_folder.SetValue(config_display_data["path_downloads"])

--- a/Sorter/configurator.py
+++ b/Sorter/configurator.py
@@ -1,24 +1,28 @@
 ''' Manipulates configuration files for TidyCobra '''
 from wx.lib.pubsub import pub
 import json
-class Configurator():
+import os
 
+
+class Configurator():
 
     def listener_configurator(self, message, arg2=None):
         print(message)
 
         ### Save config ###
         if message == "save_config":
-            print("received=",arg2)
-            with open('../Sorter/config.json', 'w+') as f:
-                json.dump(arg2,f)
+            print("received=", arg2)
+            cwd = os.getcwd()
+            path = os.path.join(cwd, "Sorter", "config.json")
+            with open(path, 'w+') as f:
+                json.dump(arg2, f)
             print("done")
         ### Load config ###
         elif message == "import_config":
-            #TODO:implement
+            # TODO:implement
             return -1
 
-    def load_config(self,path):
+    def load_config(self, path):
         with open(path) as f:
             config = json.load(f)
             return config
@@ -27,5 +31,3 @@ class Configurator():
 
         data = []
         pub.subscribe(self.listener_configurator, "configuratorListener")
-
-

--- a/Sorter/sorter.py
+++ b/Sorter/sorter.py
@@ -2,34 +2,41 @@
 from Sorter import configurator as config_module
 import glob, os, shutil
 from datetime import datetime
+
+
 class Sorter:
 
-    def fix_duplicate(self,path):
+    def fix_duplicate(self, path):
         # hacky way to handle path duplication
         new_name = path.split(".")
-        new_name[0] += "_duplicate" + str(int(datetime.timestamp(datetime.now()))%1000000)
+        new_name[0] += "_duplicate" + str(int(datetime.timestamp(datetime.now())) % 1000000)
         return ".".join(new_name)
-    def sort(self,path_destination,extensions):
+
+    def sort(self, path_destination, extensions):
         for extension in extensions:
             print(extension)
-            for file in glob.glob("*"+extension):
+            for file in glob.glob("*" + extension):
+                if not os.path.exists(path_destination) and os.path.isdir(path_destination):
+                    continue
                 print(file)
-                current_file_path = self.path_downloads+"/"+file
-                new_file_path = path_destination+"/"+file
+                current_file_path = self.path_downloads + "/" + file
+                new_file_path = path_destination + "/" + file
                 if os.path.isfile(new_file_path):
                     new_file_path = self.fix_duplicate(new_file_path)
 
-                shutil.move(current_file_path,new_file_path)
-    print("done!")
+                shutil.move(current_file_path, new_file_path)
 
+    print("done!")
 
     def __init__(self):
         configurator = config_module.Configurator()
-        self.config = configurator.load_config("../Sorter/config.json")
-        self.path_downloads = self.config["path_downloads"]
         old_path = os.getcwd()
+        path_config = os.path.join(old_path, "Sorter", "config.json")
+        self.config = configurator.load_config(path_config)
+        self.path_downloads = self.config["path_downloads"]
+
         os.chdir(self.path_downloads)
-        print("path_dw:",self.path_downloads,"current dir",os.getcwd())
+        print("path_dw:", self.path_downloads, "current dir", os.getcwd())
         for rule in self.config["rules"]:
             path_destination = rule[0]
             extensions = rule[1].split(' ')


### PR DESCRIPTION
Hello! I was taking a look at some of the issues in this repository

Regarding the issue #9, I found this [discussion](https://stackoverflow.com/questions/58301366/lost-files-while-tried-to-move-files-using-python-shutil-move) that states files can get corrupted if the destination folder doesn't exists

In the discussion is suggested to use this validation before actually moving a file:

```python
if not os.path.exists(path_destination) and os.path.isdir(path_destination):
    continue
```

Also I saw #6 and #5 and I believe the changes in how paths are created to use `os.path.join` might help with those issues